### PR TITLE
fix: sale list page search and report data

### DIFF
--- a/inventory/templates/inventory/sale_list.html
+++ b/inventory/templates/inventory/sale_list.html
@@ -139,7 +139,7 @@
                                         <i class="bi bi-currency-yen text-success fs-4"></i>
                                     </div>
                                 </div>
-                                <h3 class="mb-0 text-success fw-bold">¥{{ today_sales|default:"0.00" }}</h3>
+                                <h3 class="mb-0 text-success fw-bold">¥{{ today_sales|floatformat:2|default:"0.00" }}</h3>
                                 <div class="progress mt-3" style="height: 4px;">
                                     <div class="progress-bar bg-success" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
                                 </div>
@@ -155,7 +155,7 @@
                                         <i class="bi bi-bar-chart-line text-primary fs-4"></i>
                                     </div>
                                 </div>
-                                <h3 class="mb-0 text-primary fw-bold">¥{{ month_sales|default:"0.00" }}</h3>
+                                <h3 class="mb-0 text-primary fw-bold">¥{{ month_sales|floatformat:2|default:"0.00" }}</h3>
                                 <div class="progress mt-3" style="height: 4px;">
                                     <div class="progress-bar bg-primary" role="progressbar" style="width: 65%" aria-valuenow="65" aria-valuemin="0" aria-valuemax="100"></div>
                                 </div>
@@ -171,7 +171,7 @@
                                         <i class="bi bi-receipt text-info fs-4"></i>
                                     </div>
                                 </div>
-                                <h3 class="mb-0 text-info fw-bold">{{ sales|length }}</h3>
+                                <h3 class="mb-0 text-info fw-bold">{{ total_sales }}</h3>
                                 <div class="progress mt-3" style="height: 4px;">
                                     <div class="progress-bar bg-info" role="progressbar" style="width: 85%" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100"></div>
                                 </div>
@@ -378,9 +378,10 @@
                     row.style.display = 'none';
                 }
             });
-            
-            // 检查是否有可见行
-            const visibleRows = document.querySelectorAll('.sale-row[style="display: "]');
+            const visibleRows = Array.from(rows).filter(row => {
+                const style = window.getComputedStyle(row);
+                return style.display !== 'none';
+            });
             const noResultsRow = document.querySelector('.no-results-row');
             
             if (visibleRows.length === 0 && rows.length > 0) {


### PR DESCRIPTION
修复：
 - 销售列表页面订单搜索存在结果时，仍会显示“未找到匹配的销售记录”的问题
 - 缺失`今日销售额` / `本月销售额` / `总订单数`数据的问题