### PR TITLE
fix: handle leap-day birthdays in reports

### DIFF
--- a/inventory/tests/test_birthday_report.py
+++ b/inventory/tests/test_birthday_report.py
@@ -1,0 +1,61 @@
+from datetime import date, datetime, timezone
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from inventory.models import Member, MemberLevel
+
+
+class BirthdayReportTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username='birthday-report-test')
+        cls.level = MemberLevel.objects.create(
+            name='Birthday test', discount='1.00', points_threshold=0,
+        )
+        cls.member = Member.objects.create(
+            name='Leap birthday', phone='10000000000',
+            level=cls.level, birthday=date(2000, 2, 29),
+        )
+
+    def report_on(self, today, month=2):
+        now = datetime.combine(today, datetime.min.time(), tzinfo=timezone.utc)
+        with patch('inventory.views.sales.timezone.now', return_value=now):
+            self.client.force_login(self.user)
+            return self.client.get(reverse('birthday_members_report'), {'month': month})
+
+    def test_leap_birthday_does_not_break_non_leap_year_report(self):
+        response = self.report_on(date(2026, 2, 25))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context['members']), [self.member])
+        self.assertEqual(response.context['upcoming_birthdays'], [])
+
+    def test_leap_birthday_after_leap_day_does_not_construct_invalid_next_year(self):
+        response = self.report_on(date(2028, 3, 1))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['upcoming_birthdays'], [])
+
+    def test_leap_day_is_included_within_seven_days(self):
+        response = self.report_on(date(2028, 2, 22))
+        upcoming = response.context['upcoming_birthdays']
+        self.assertEqual(len(upcoming), 1)
+        self.assertEqual(upcoming[0]['birthday_date'], date(2028, 2, 29))
+        self.assertEqual(upcoming[0]['days_until_birthday'], 7)
+
+    def test_today_is_included(self):
+        response = self.report_on(date(2028, 2, 29))
+        self.assertEqual(response.context['upcoming_birthdays'][0]['days_until_birthday'], 0)
+
+    def test_more_than_seven_days_is_excluded(self):
+        response = self.report_on(date(2028, 2, 21))
+        self.assertEqual(response.context['upcoming_birthdays'], [])
+
+    def test_ordinary_birthday_across_year_boundary(self):
+        self.member.birthday = date(2000, 1, 2)
+        self.member.save(update_fields=['birthday'])
+        response = self.report_on(date(2026, 12, 30), month=1)
+        upcoming = response.context['upcoming_birthdays']
+        self.assertEqual(upcoming[0]['birthday_date'], date(2027, 1, 2))
+        self.assertEqual(upcoming[0]['days_until_birthday'], 3)

--- a/inventory/views/sales.py
+++ b/inventory/views/sales.py
@@ -916,16 +916,19 @@ def birthday_members_report(request):
     # 即将到来的生日会员(7天内)
     today = timezone.now().date()
     upcoming_birthdays = []
+    upcoming_dates = {}
+    for days_ahead in range(8):
+        birthday_date = today + timedelta(days=days_ahead)
+        upcoming_dates[(birthday_date.month, birthday_date.day)] = birthday_date
     
     for member in members:
         if member.birthday:
-            # 计算今年的生日日期
-            current_year = today.year
-            birthday_this_year = date(current_year, member.birthday.month, member.birthday.day)
-            
-            # 如果今年的生日已经过了，计算明年的生日
-            if birthday_this_year < today:
-                birthday_this_year = date(current_year + 1, member.birthday.month, member.birthday.day)
+            # 仅匹配真实存在的日期，避免在平年构造 2 月 29 日。
+            birthday_this_year = upcoming_dates.get(
+                (member.birthday.month, member.birthday.day)
+            )
+            if birthday_this_year is None:
+                continue
             
             # 计算距离生日还有多少天
             days_until_birthday = (birthday_this_year - today).days


### PR DESCRIPTION
## 问题与修复

Fixes #88

生日报表将会员生日直接替换成当前年或下一年的日期，遇到平年中的 2 月 29 日会抛出 `ValueError`，使整页无法显示。

本 PR 只调整该报表的“未来七天生日”计算：先建立今天至第七天真实存在的日期，再匹配会员的月日。保持月份筛选、排序和会员列表不变；2 月 29 日会员仍显示在二月份列表中，不会被改成 2 月 28 日或 3 月 1 日。没有修改余额、库存、权限、模型、依赖或迁移。

## 验证

- 新增 6 个 Django 回归测试：平年、闰日已过后的下一年、七天边界、当天、八天外、跨年普通生日。未修复视图上其中 2 项以 `ValueError` 失败，修复后 6 项全通过。
- `python -X utf8 manage.py test inventory.tests.test_birthday_report inventory.tests.test_i18n inventory.tests.test_auth --noinput`：9 项通过。
- `python -X utf8 manage.py makemigrations --check --dry-run`：无模型变化。
- `git diff --check`：通过。
- 完整测试：50 项中 46 项通过、4 项既存失败，与未修改 `main` 上的 44 项测试中 4 项失败一致：盘点权限夹具、两处旧销售创建夹具、旧商品表单路径断言。没有将全套测试描述为通过。

环境：Windows、Python 3.13.13、Django 6.1.1；仅本地合成数据。既存的 `staticfiles.W004` 警告未改动。使用 Python UTF-8 模式避免本机控制台编码影响无关中文日志。
