### PR TITLE
fix: avoid transaction shadowing in member balance views

### DIFF
--- a/inventory/tests/test_member_transaction_shadowing.py
+++ b/inventory/tests/test_member_transaction_shadowing.py
@@ -1,0 +1,92 @@
+from decimal import Decimal
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from inventory.models import Member, MemberLevel, MemberTransaction, RechargeRecord
+
+
+class MemberBalanceTransactionTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="operator", password="secret")
+        level = MemberLevel.objects.create(
+            name="Standard", discount=Decimal("1.00"), points_threshold=0
+        )
+        self.member = Member.objects.create(
+            name="Synthetic member",
+            phone="5550000001",
+            level=level,
+            balance=Decimal("10.00"),
+        )
+        self.client.login(username="operator", password="secret")
+
+    def test_recharge_updates_balance_and_creates_ledger_entry(self):
+        response = self.client.post(
+            reverse("member_recharge", args=[self.member.pk]),
+            {
+                "amount": "5.25",
+                "actual_amount": "5.25",
+                "payment_method": "cash",
+                "remark": "synthetic recharge",
+            },
+        )
+
+        self.assertRedirects(response, reverse("member_detail", args=[self.member.pk]))
+        self.member.refresh_from_db()
+        self.assertEqual(self.member.balance, Decimal("15.25"))
+        self.assertTrue(self.member.is_recharged)
+        self.assertEqual(RechargeRecord.objects.count(), 1)
+        self.assertEqual(
+            list(MemberTransaction.objects.values_list("transaction_type", flat=True)),
+            ["RECHARGE"],
+        )
+
+    def test_balance_adjust_updates_balance_and_creates_ledger_entry(self):
+        response = self.client.post(
+            reverse("member_balance_adjust", args=[self.member.pk]),
+            {"balance_change": "-2.50", "description": "synthetic adjustment"},
+        )
+
+        self.assertRedirects(response, reverse("member_detail", args=[self.member.pk]))
+        self.member.refresh_from_db()
+        self.assertEqual(self.member.balance, Decimal("7.50"))
+        transaction = MemberTransaction.objects.get()
+        self.assertEqual(transaction.transaction_type, "BALANCE_ADJUST")
+        self.assertEqual(transaction.balance_change, Decimal("-2.50"))
+
+    def test_recharge_rolls_back_ledger_and_balance_on_failure(self):
+        with patch(
+            "inventory.views.member.member_service.apply_member_balance_change",
+            side_effect=RuntimeError("synthetic failure"),
+        ):
+            with self.assertRaises(RuntimeError):
+                self.client.post(
+                    reverse("member_recharge", args=[self.member.pk]),
+                    {
+                        "amount": "5.25",
+                        "actual_amount": "5.25",
+                        "payment_method": "cash",
+                    },
+                )
+
+        self.member.refresh_from_db()
+        self.assertEqual(self.member.balance, Decimal("10.00"))
+        self.assertEqual(RechargeRecord.objects.count(), 0)
+        self.assertEqual(MemberTransaction.objects.count(), 0)
+
+    def test_balance_adjust_rolls_back_ledger_and_balance_on_failure(self):
+        with patch(
+            "inventory.views.member.member_service.apply_member_balance_change",
+            side_effect=RuntimeError("synthetic failure"),
+        ):
+            with self.assertRaises(RuntimeError):
+                self.client.post(
+                    reverse("member_balance_adjust", args=[self.member.pk]),
+                    {"balance_change": "2.50", "description": "synthetic failure"},
+                )
+
+        self.member.refresh_from_db()
+        self.assertEqual(self.member.balance, Decimal("10.00"))
+        self.assertEqual(MemberTransaction.objects.count(), 0)

--- a/inventory/tests/test_member_transaction_shadowing.py
+++ b/inventory/tests/test_member_transaction_shadowing.py
@@ -6,9 +6,15 @@ from django.test import TestCase
 from django.urls import reverse
 
 from inventory.models import Member, MemberLevel, MemberTransaction, RechargeRecord
+from inventory.services.member_service import apply_member_balance_change
 
 
 class MemberBalanceTransactionTests(TestCase):
+    @staticmethod
+    def update_balance_then_fail(*args, **kwargs):
+        apply_member_balance_change(*args, **kwargs)
+        raise RuntimeError("synthetic failure after balance update")
+
     def setUp(self):
         self.user = User.objects.create_user(username="operator", password="secret")
         level = MemberLevel.objects.create(
@@ -59,7 +65,7 @@ class MemberBalanceTransactionTests(TestCase):
     def test_recharge_rolls_back_ledger_and_balance_on_failure(self):
         with patch(
             "inventory.views.member.member_service.apply_member_balance_change",
-            side_effect=RuntimeError("synthetic failure"),
+            side_effect=self.update_balance_then_fail,
         ):
             with self.assertRaises(RuntimeError):
                 self.client.post(
@@ -73,13 +79,14 @@ class MemberBalanceTransactionTests(TestCase):
 
         self.member.refresh_from_db()
         self.assertEqual(self.member.balance, Decimal("10.00"))
+        self.assertFalse(self.member.is_recharged)
         self.assertEqual(RechargeRecord.objects.count(), 0)
         self.assertEqual(MemberTransaction.objects.count(), 0)
 
     def test_balance_adjust_rolls_back_ledger_and_balance_on_failure(self):
         with patch(
             "inventory.views.member.member_service.apply_member_balance_change",
-            side_effect=RuntimeError("synthetic failure"),
+            side_effect=self.update_balance_then_fail,
         ):
             with self.assertRaises(RuntimeError):
                 self.client.post(

--- a/inventory/views/member.py
+++ b/inventory/views/member.py
@@ -598,7 +598,7 @@ def member_recharge(request, pk):
             if remark:
                 description_text += f' ({remark})'
 
-            member_transaction = MemberTransaction.objects.create(
+            MemberTransaction.objects.create(
                 member=member,
                 transaction_type='RECHARGE',
                 balance_change=amount,
@@ -655,7 +655,7 @@ def member_balance_adjust(request, pk):
                 member = get_object_or_404(Member.objects.select_for_update(), pk=pk)
 
                 # 创建余额交易记录
-                member_transaction = MemberTransaction.objects.create(
+                MemberTransaction.objects.create(
                     member=member,
                     transaction_type='BALANCE_ADJUST',
                     balance_change=balance_change,

--- a/inventory/views/member.py
+++ b/inventory/views/member.py
@@ -598,7 +598,7 @@ def member_recharge(request, pk):
             if remark:
                 description_text += f' ({remark})'
 
-            transaction = MemberTransaction.objects.create(
+            member_transaction = MemberTransaction.objects.create(
                 member=member,
                 transaction_type='RECHARGE',
                 balance_change=amount,
@@ -655,7 +655,7 @@ def member_balance_adjust(request, pk):
                 member = get_object_or_404(Member.objects.select_for_update(), pk=pk)
 
                 # 创建余额交易记录
-                transaction = MemberTransaction.objects.create(
+                member_transaction = MemberTransaction.objects.create(
                     member=member,
                     transaction_type='BALANCE_ADJUST',
                     balance_change=balance_change,


### PR DESCRIPTION
## 问题与修复

Fixes #90

`member_recharge` 与 `member_balance_adjust` 在 `with transaction.atomic()` 之后将 `MemberTransaction.objects.create(...)` 的返回值赋给同名局部变量 `transaction`。因此有效 POST 会先在事务入口抛出 `UnboundLocalError`。

本 PR 仅移除两处未使用的赋值，保留创建交易记录的调用、已有原子事务、行锁和余额服务。新增 4 个使用真实路由的 Django 测试：充值成功、余额调整成功，以及两种操作在余额已写入后发生异常时回滚余额与相关记录。没有模型、迁移、依赖、权限、公共接口或 UI 布局变化。

## 验证

- 未修复的 `main` 上，两种有效 POST 都复现事务入口的 `UnboundLocalError`。
- `python -X utf8 manage.py test inventory.tests.test_member_transaction_shadowing`：4/4 通过，分别在 Python 3.10.20 / Django 5.2.17 和 Python 3.13.13 / Django 6.1.1 验证。
- `python -X utf8 manage.py test --noinput`：Python 3.13 环境 48 项中 44 项通过，4 项失败与原始 `main` 的 44 项中 4 项既存失败一致（盘点权限夹具、两个旧销售创建夹具、旧商品表单路径断言）。并非全套测试通过。
- `git diff --check`：通过。

验证仅使用本地合成会员与隔离测试数据库，没有访问真实业务数据。保留既有 `staticfiles.W004` 警告；回滚测试会有预期的合成异常日志。此 PR 与生日报表 #89 和库存表单 #69 独立，不改变已有并发更新策略。
